### PR TITLE
chore(docker): add ignore file, minor fixes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+package-lock.json
+yarn.lock
+node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM node:15.3.0-alpine3.10
+FROM node:lts-alpine3.10
 
-# Labls
+# Labels
 LABEL maintainer="Yash Kumar Verma yk.verma2000@gmail.com"
 
 # Document environment configurations
@@ -11,20 +11,19 @@ ENV database ='mongodb://127.0.0.1:27017/authentico'
 WORKDIR /app
 
 # Only copy the package.json file to work directory
-COPY package.json /app
-
+COPY package.json .
 
 # Install all Packages
 RUN npm install
 
 # Copy all other source code to work directory
-ADD . /app
+COPY . .
 
 # Build the project
 RUN npm run build
-RUN docker compose up
+# RUN docker compose up
 
 # run the server
-CMD ["npm", "start:dev"] 
+CMD ["npm", "run", "start:dev"] 
 
 EXPOSE 80


### PR DESCRIPTION
# Issue Related with PR
- fixes #112 

# Proposed Changes
- Added a .dockerignore file to ignore node_modules and lock files.
- Used docker image node:lts-alpine3.10 to avoid incompatibilities of certain packages with npm version.

# Additional info if necessary
- I have commented out docker-compose as of now because docker command won't be present in the container. I thought it would be better if we discuss it before making further changes to dockerfile

# Checklist
- [-] Tests
- [-] Resolve Conflicts

# Screenshots
- None
